### PR TITLE
Add Base.propertynames() for all types that define getproperty()

### DIFF
--- a/src/results.jl
+++ b/src/results.jl
@@ -26,7 +26,16 @@ _data(result::TransactionResult) = getfield(result, :_data)
 
 Base.getindex(result::TransactionResult, key) = _data(result)[key]
 
+function Base.propertynames(result::TransactionResult, private::Bool=false)
+    data = _data(result)
+    names = (keys(data)..., :relations)
+    if private
+        names = (names..., fieldnames(TransactionResult)...)
+    end
+    return names
+end
 function Base.getproperty(result::TransactionResult, name::Symbol)
+    name in fieldnames(TransactionResult) && return getfield(result, name)
     data = _data(result)
     name == :relations && return Relations(data.output)
     return data[name]
@@ -148,7 +157,16 @@ end
 Base.eltype(::Relation) = RelRow
 Base.getindex(relation::Relation, key::Int) = getrow(relation, key)
 
+function Base.propertynames(relation::Relation, private::Bool=false)
+    data = _data(relation)
+    names = (keys(data)..., :name)
+    if private
+        names = (names..., fieldnames(Relation)...)
+    end
+    return names
+end
 function Base.getproperty(relation::Relation, name::Symbol)
+    name in fieldnames(Relation) && return getfield(result, name)
     data = _data(relation)
     name == :name && return data.rel_key.name
     return _data(relation)[name]
@@ -247,6 +265,9 @@ _indexof(row, name) = findfirst(==(name), _names(row))
 
 Base.getindex(row::RelRow, key::Int) = _values(row)[key]
 
+function Base.propertynames(row::RelRow)
+    return (_names(row)..., fieldnames(RelRow))
+end
 function Base.getproperty(row::RelRow, name::Symbol)
     name in _names(row) && return getcolumn(row, name)
     return getfield(row, name)


### PR DESCRIPTION
@bradlo: this is just a very small mechanical change - it doesn't change anything about how the SDK is set up, it just makes the TransactionResult object slightly easier to use at the REPL. 😊 

------

If you implement Base.getproperty(), you're supposed to also implement
Base.propertynames(). Of course it's hard to _know_ you're supposed to
do that because julia doesn't have interfaces :P

From the help docstring:
```julia

help?> Base.propertynames
  propertynames(x, private=false)

  Get a tuple or a vector of the properties (x.property) of an object
  x. This is typically the same as fieldnames(typeof(x)), but types
  that overload getproperty should generally overload propertynames
  as well to get the properties of an instance of the type.

  propertynames(x) may return only "public" property names that are
  part of the documented interface of x. If you want it to also
  return "private" fieldnames intended for internal use, pass true
  for the optional second argument. REPL tab completion on x. shows
  only the private=false properties.

  See also: hasproperty, hasfield.
```

This allows you to discover, at the repl, how to use these types, via
tab-complete:
```julia
julia> r = TransactionResult(exec(config..., """2+2"""))
// output Int64
4

julia> r.  # <tab>
aborted     actions      debug_level  output       problems     relations    type
julia> rr = r.relations[1]
// output Int64
4

julia> rr.  # <tab>
columns name     rel_key  type
julia> rr.columns
1-element JSON3.Array{JSON3.Array, Vector{UInt8}, SubArray{UInt64, 1, Vector{UInt64}, Tuple{UnitRange{Int64}}, true}}:
 [4]

```