### PR TITLE
Support v2 "async" transactions returning multipart Arrow responses

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
 ConfParser = "88353bc9-fd38-507d-a820-d3b43837d6b9"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ ConfParser = "88353bc9-fd38-507d-a820-d3b43837d6b9"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]

--- a/examples/exec_async.jl
+++ b/examples/exec_async.jl
@@ -1,0 +1,59 @@
+# Copyright 2022 RelationalAI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+# Execute the given query string.
+# Example:
+# $ julia --proj=. examples/exec_async.jl "nhd-test-1" "nhd-s" "2+2"
+# Transaction is done...
+# JSON3.Object{Vector{UInt8}, Vector{UInt64}} with 2 entries:
+#   :id    => "261f5d59-f1b4-f778-4c13-a7993871c972"
+#   :state => "CREATED"
+
+import RAI
+using RAI: Context, HTTPError, exec_async, load_config, show_result, get_transaction
+
+include("parseargs.jl")
+
+function run(database, engine, source; profile)
+    conf = load_config(; profile = profile)
+    ctx = Context(conf)
+    txn = exec_async(ctx, database, engine, source)
+    println("Transaction is created...")
+    display(txn)
+    println()
+end
+
+function main()
+    args = parseargs(
+        "database", Dict(:help => "database name", :required => true),
+        "engine", Dict(:help => "engine name", :required => true),
+        "command", Dict(:help => "rel source string"),
+        ["--file", "-f"], Dict(:help => "rel source file"),
+        "--readonly", Dict(:help => "readonly query (default: false)", :action => "store_true"),
+        "--profile", Dict(:help => "config profile (default: default)"))
+    try
+        source = nothing
+        if !isnothing(args.command)
+            source = args.command
+        elseif !isnothing(args.file)
+            source = open(args.file, "r")
+        end
+        isnothing(source) && return  # nothing to execute
+        run(args.database, args.engine, source; profile = args.profile)
+    catch e
+        e isa HTTPError ? show(e) : rethrow()
+    end
+end
+
+main()

--- a/src/RAI.jl
+++ b/src/RAI.jl
@@ -69,9 +69,16 @@ export
 
 export
     exec,
+    exec_async,
     list_edbs,
     load_csv,
     load_json
+
+export
+    get_transaction,
+    get_transaction_metadata,
+    get_transaction_problems,
+    get_transaction_results
 
 export
     Relation,

--- a/src/api.jl
+++ b/src/api.jl
@@ -394,7 +394,7 @@ function get_transaction(ctx::Context, id::AbstractString; kw...)
 end
 
 function transaction_is_done(txn)
-    if hasproperty(txn, :transaction)
+    if haskey(txn, :transaction)
         txn = txn.transaction
     end
     return txn.state ∈ ("COMPLETED", "ABORTED")

--- a/src/api.jl
+++ b/src/api.jl
@@ -21,7 +21,7 @@
 import JSON3
 import Arrow
 
-using Mocking: Mocking,@mock  # For unit testing, by mocking API server responses
+using Mocking: Mocking, @mock  # For unit testing, by mocking API server responses
 
 const PATH_DATABASE = "/database"
 const PATH_ENGINE = "/compute"

--- a/src/api.jl
+++ b/src/api.jl
@@ -394,10 +394,10 @@ function get_transaction(ctx::Context, id::AbstractString; kw...)
 end
 
 function transaction_is_done(txn)
-    if haskey(txn, :transaction)
-        txn = txn.transaction
+    if haskey(txn, "transaction")
+        txn = txn["transaction"]
     end
-    return txn.state ∈ ("COMPLETED", "ABORTED")
+    return txn["state"] ∈ ("COMPLETED", "ABORTED")
 end
 
 function get_transaction_metadata(ctx::Context, id::AbstractString; kw...)

--- a/src/api.jl
+++ b/src/api.jl
@@ -343,7 +343,7 @@ end
 
 # Execute the given query string, using any given optioanl query inputs.
 # todo: consider create_transaction
-# todo: consider create_transaction to better align with future transaciton
+# todo: consider create_transaction to better align with future transaction
 #   resource model
 function exec(ctx::Context, database::AbstractString, engine::AbstractString, source; inputs = nothing, readonly = false, kw...)
     source isa IO && (source = read(source, String))
@@ -354,7 +354,7 @@ end
 # todo: when we have async transactions, add a variation that dispatches and
 #   waits .. consider creating two entry points for readonly and readwrite.
 
-function exec_v2(ctx::Context, database::AbstractString, engine::AbstractString, source; inputs = nothing, readonly = false, kw...)
+function exec_async(ctx::Context, database::AbstractString, engine::AbstractString, source; inputs = nothing, readonly = false, kw...)
     source isa IO && (source = read(source, String))
     tx_body = Dict(
         "dbname" => database,

--- a/src/api.jl
+++ b/src/api.jl
@@ -440,11 +440,11 @@ function _parse_multipart_fastpath_sync_response(msg)
         results = _extract_multipart_results_response(@view(parts[results_start_idx:end]))
     end
 
-    return (
-        transaction = JSON3.read(parts[1]),
-        metadata = JSON3.read(parts[2]),
-        problems = problems,
-        results = results,
+    return Dict(
+        "transaction" => JSON3.read(parts[1]),
+        "metadata" => JSON3.read(parts[2]),
+        "problems" => problems,
+        "results" => results,
     )
 end
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -423,11 +423,6 @@ function get_transaction_results(ctx::Context, id::AbstractString; kw...)
     return _parse_multipart_results_response(rsp)
 end
 
-struct ResultPhysicalRelation
-    name::String
-    data::Arrow.Table
-end
-
 function _parse_multipart_fastpath_sync_response(msg)
     # TODO: in-place conversion to Arrow without copying the bytes.
     #   ... HTTP.parse_multipart_form() copies the bytes into IOBuffers.
@@ -461,7 +456,7 @@ function _parse_multipart_results_response(msg)
 end
 function _extract_multipart_results_response(parts)
     return [
-        ResultPhysicalRelation(part.name, Arrow.Table(part.data)) for part in parts
+        (part.name => Arrow.Table(part.data)) for part in parts
     ]
 end
 

--- a/test/api.jl
+++ b/test/api.jl
@@ -91,8 +91,8 @@ end
             expected_data = make_arrow_table([4])
             # Arrow.Tables can't be compared via == (https://github.com/apache/arrow-julia/issues/310)
             @test length(rsp.results) == 1
-            @test rsp.results[1].name == "/:output/Int64"
-            @test collect(rsp.results[1].data) == collect(expected_data)
+            @test rsp.results[1][1] == "/:output/Int64"
+            @test collect(rsp.results[1][2]) == collect(expected_data)
         end
     end
 end

--- a/test/api.jl
+++ b/test/api.jl
@@ -1,0 +1,97 @@
+using RAI
+using Test
+import HTTP, Arrow
+using Mocking
+
+Mocking.activate()
+
+# -----------------------------------
+# v2 transactions
+
+make_patch(response) = @patch RAI.request(ctx::Context, args...; kw...) = response
+
+const v2_async_response = HTTP.Response(200, [
+        "Content-Type" => "application/json",
+    ],
+    body = """{"id":"1fc9001b-1b88-8685-452e-c01bc6812429","state":"CREATED"}""")
+
+const v2_get_results_response() = join([
+        "--8a89e52be8efe57f0b68ea75388314a3",
+        "Content-Disposition: form-data; name=\"/:output/Int64\"; filename=\"/:output/Int64\"",
+        "Content-Type: application/vnd.apache.arrow.stream",
+        "",
+        "\xff\xff\xff\xffx\0\0\0\x10\0\0\0\0\0\n\0\f\0\n\0\b\0\x04\0\n\0\0\0\x10\0\0\0\x01\0\x04\0\b\0\b\0\0\0\x04\0\b\0\0\0\x04\0\0\0\x01\0\0\0\x14\0\0\0\x10\0\x14\0\x10\0\0\0\x0e\0\b\0\0\0\x04\0\x10\0\0\0\x10\0\0\0\x18\0\0\0\0\0\x02\0\x1c\0\0\0\0\0\0\0\b\0\f\0\b\0\a\0\b\0\0\0\0\0\0\x01@\0\0\0\x02\0\0\0v1\0\0\xff\xff\xff\xff\x88\0\0\0\x14\0\0\0\0\0\0\0\f\0\x16\0\x14\0\x12\0\f\0\x04\0\f\0\0\0\b\0\0\0\0\0\0\0\x14\0\0\0\0\0\x03\0\x04\0\n\0\x18\0\f\0\b\0\x04\0\n\0\0\0\x14\0\0\08\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\x02\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\b\0\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x04\0\0\0\0\0\0\0\xff\xff\xff\xff\0\0\0\0",
+    ], "\r\n")
+
+const v2_fastpath_response = HTTP.Response(200, [
+        "Content-Type" => "Content-Type: multipart/form-data; boundary=8a89e52be8efe57f0b68ea75388314a3",
+        "Transfer-Encoding" => "chunked",
+    ],
+    body = join([
+    "",
+    "--8a89e52be8efe57f0b68ea75388314a3",
+    "Content-Disposition: form-data; name=\"transaction\"; filename=\"\"",
+    "Content-Type: application/json",
+    "",
+    """{"id":"a3e3bc91-0a98-50ba-733c-0987e160eb7d","results_format_version":"2.0.1","state":"COMPLETED"}""",
+    "--8a89e52be8efe57f0b68ea75388314a3",
+    "Content-Disposition: form-data; name=\"metadata\"; filename=\"\"",
+    "Content-Type: application/json",
+    "",
+    """[{"relationId":"/:output/Int64","types":[":output","Int64"]}]""",
+    "--8a89e52be8efe57f0b68ea75388314a3",
+    "Content-Disposition: form-data; name=\"problems\"; filename=\"\"",
+    "Content-Type: application/json",
+    "",
+    """[]""",
+    v2_get_results_response(),
+    "--8a89e52be8efe57f0b68ea75388314a3--",
+    "",
+], "\r\n"))
+
+function make_arrow_table(vals)
+    io = IOBuffer()
+    Arrow.write(io, (v1=vals,))
+    seekstart(io)
+    return Arrow.Table(io)
+end
+
+@testset "exec_v2" begin
+    ctx = Context("region", "scheme", "host", "2342", nothing)
+
+    @testset "async response" begin
+        patch = make_patch(v2_async_response)
+
+        apply(patch) do
+            rsp = RAI.exec_v2(ctx, "engine", "database", "2+2")
+            @test rsp == JSON3.read("""{"id":"1fc9001b-1b88-8685-452e-c01bc6812429","state":"CREATED"}""")
+        end
+    end
+
+    @testset "sync response" begin
+        patch = make_patch(v2_fastpath_response)
+
+        apply(patch) do
+            data = make_arrow_table([4])
+            rsp = RAI.exec_v2(ctx, "engine", "database", "2+2")
+            @test rsp.transaction == JSON3.read("""{
+                    "id": "a3e3bc91-0a98-50ba-733c-0987e160eb7d",
+                    "results_format_version": "2.0.1",
+                    "state": "COMPLETED"
+                }""")
+            @test rsp.metadata == [JSON3.read("""{
+                "relationId": "/:output/Int64",
+                    "types": [
+                                ":output",
+                                "Int64"
+                            ]
+            }""")]
+            @test rsp.problems == Union{}[]
+
+            # Arrow.Tables can't be compared via == (https://github.com/apache/arrow-julia/issues/310)
+            @test length(rsp.relations) == 1
+            @test rsp.relations[1].name == "/:output/Int64"
+            @test collect(rsp.relations[1].data) == collect(data)
+        end
+    end
+end

--- a/test/api.jl
+++ b/test/api.jl
@@ -72,7 +72,6 @@ end
         patch = make_patch(v2_fastpath_response)
 
         apply(patch) do
-            data = make_arrow_table([4])
             rsp = RAI.exec_v2(ctx, "engine", "database", "2+2")
             @test rsp.transaction == JSON3.read("""{
                     "id": "a3e3bc91-0a98-50ba-733c-0987e160eb7d",
@@ -88,10 +87,12 @@ end
             }""")]
             @test rsp.problems == Union{}[]
 
+            # Test for the expected arrow data:
+            expected_data = make_arrow_table([4])
             # Arrow.Tables can't be compared via == (https://github.com/apache/arrow-julia/issues/310)
             @test length(rsp.results) == 1
             @test rsp.results[1].name == "/:output/Int64"
-            @test collect(rsp.results[1].data) == collect(data)
+            @test collect(rsp.results[1].data) == collect(expected_data)
         end
     end
 end

--- a/test/api.jl
+++ b/test/api.jl
@@ -89,9 +89,9 @@ end
             @test rsp.problems == Union{}[]
 
             # Arrow.Tables can't be compared via == (https://github.com/apache/arrow-julia/issues/310)
-            @test length(rsp.relations) == 1
-            @test rsp.relations[1].name == "/:output/Int64"
-            @test collect(rsp.relations[1].data) == collect(data)
+            @test length(rsp.results) == 1
+            @test rsp.results[1].name == "/:output/Int64"
+            @test collect(rsp.results[1].data) == collect(data)
         end
     end
 end

--- a/test/api.jl
+++ b/test/api.jl
@@ -73,26 +73,26 @@ end
 
         apply(patch) do
             rsp = RAI.exec_async(ctx, "engine", "database", "2+2")
-            @test rsp.transaction == JSON3.read("""{
+            @test rsp["transaction"] == JSON3.read("""{
                     "id": "a3e3bc91-0a98-50ba-733c-0987e160eb7d",
                     "results_format_version": "2.0.1",
                     "state": "COMPLETED"
                 }""")
-            @test rsp.metadata == [JSON3.read("""{
+            @test rsp["metadata"] == [JSON3.read("""{
                 "relationId": "/:output/Int64",
                     "types": [
                                 ":output",
                                 "Int64"
                             ]
             }""")]
-            @test rsp.problems == Union{}[]
+            @test rsp["problems"] == Union{}[]
 
             # Test for the expected arrow data:
             expected_data = make_arrow_table([4])
             # Arrow.Tables can't be compared via == (https://github.com/apache/arrow-julia/issues/310)
-            @test length(rsp.results) == 1
-            @test rsp.results[1][1] == "/:output/Int64"
-            @test collect(rsp.results[1][2]) == collect(expected_data)
+            @test length(rsp["results"]) == 1
+            @test rsp["results"][1][1] == "/:output/Int64"
+            @test collect(rsp["results"][1][2]) == collect(expected_data)
         end
     end
 end

--- a/test/api.jl
+++ b/test/api.jl
@@ -56,14 +56,14 @@ function make_arrow_table(vals)
     return Arrow.Table(io)
 end
 
-@testset "exec_v2" begin
+@testset "exec_async" begin
     ctx = Context("region", "scheme", "host", "2342", nothing)
 
     @testset "async response" begin
         patch = make_patch(v2_async_response)
 
         apply(patch) do
-            rsp = RAI.exec_v2(ctx, "engine", "database", "2+2")
+            rsp = RAI.exec_async(ctx, "engine", "database", "2+2")
             @test rsp == JSON3.read("""{"id":"1fc9001b-1b88-8685-452e-c01bc6812429","state":"CREATED"}""")
         end
     end
@@ -72,7 +72,7 @@ end
         patch = make_patch(v2_fastpath_response)
 
         apply(patch) do
-            rsp = RAI.exec_v2(ctx, "engine", "database", "2+2")
+            rsp = RAI.exec_async(ctx, "engine", "database", "2+2")
             @test rsp.transaction == JSON3.read("""{
                     "id": "a3e3bc91-0a98-50ba-733c-0987e160eb7d",
                     "results_format_version": "2.0.1",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,10 @@ import Tables
 using RAI
 using Test
 
+@testset "api.jl" begin
+    include("api.jl")
+end
+
 # def output =
 #     1, "foo", 3.4, :foo;
 #     2, "bar", 5.6, :foo


### PR DESCRIPTION
- Basic GET/PUT calls for the v2 /transactions API.
- Halfway decent return format for API functions.
- Basic mocked unit tests