### PR TITLE
Always return the same type from exec_async: a Dict().

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -378,7 +378,9 @@ function _parse_response(rsp)
     if lowercase(content_type) == "application/json"
         content = HTTP.body(rsp)
         # async mode
-        return JSON3.read(content)
+        return Dict(
+            "transaction" => JSON3.read(content),
+        )
     elseif occursin("multipart/form-data", lowercase(content_type))
         # sync mode
         return _parse_multipart_fastpath_sync_response(rsp)

--- a/test/api.jl
+++ b/test/api.jl
@@ -64,7 +64,9 @@ end
 
         apply(patch) do
             rsp = RAI.exec_async(ctx, "engine", "database", "2+2")
-            @test rsp == JSON3.read("""{"id":"1fc9001b-1b88-8685-452e-c01bc6812429","state":"CREATED"}""")
+            @test rsp == Dict(
+                "transaction" => JSON3.read("""{"id":"1fc9001b-1b88-8685-452e-c01bc6812429","state":"CREATED"}""")
+            )
         end
     end
 


### PR DESCRIPTION
In the case where we only have the tranasction resource, the Dict only
has one key: "transaction". In the case where it finishes early, we have
all the possible keys: "transaction", "results", ...

```julia
julia> @time r = RAI.exec_async(ctx, "nhd-test-1", "nhd-s", """
              def x = 1
              def x(i) = x(i-1) , i < 5000
              def output = count[x]
           """)
  1.156611 seconds (2.78 k allocations: 165.203 KiB)
Dict{String, JSON3.Object{Vector{UInt8}, Vector{UInt64}}} with 1 entry:
  "transaction" => {…

julia> @time r = RAI.exec_async(ctx, "nhd-test-1", "nhd-s", """
           2 + 2
               
           """)
  0.643462 seconds (519 allocations: 47.531 KiB)
Dict{String, Any} with 4 entries:
  "metadata"    => JSON3.Object[{…
  "problems"    => Union{}[]
  "results"     => Pair{String, Arrow.Table}["/:output/Int64"=>Arrow.Tabl…
  "transaction" => {…
```

This way you can always consistently get eg the transaction's ID via `r["transaction"]["id"]` without having to check for what type of response you got.