### PR TITLE
Add synchronous `exec()` function that polls client side in the SDK to provide synchronous behavior.

### DIFF
--- a/examples/exec.jl
+++ b/examples/exec.jl
@@ -1,0 +1,51 @@
+# Copyright 2022 RelationalAI, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+# Exeecute the given query string.
+
+using RAI: Context, HTTPError, exec, load_config, show_result
+
+include("parseargs.jl")
+
+function run(database, engine, source; profile)
+    conf = load_config(; profile = profile)
+    ctx = Context(conf)
+    rsp = exec(ctx, database, engine, source)
+    display(rsp)
+    println()
+end
+
+function main()
+    args = parseargs(
+        "database", Dict(:help => "database name", :required => true),
+        "engine", Dict(:help => "engine name", :required => true),
+        "command", Dict(:help => "rel source string"),
+        ["--file", "-f"], Dict(:help => "rel source file"),
+        "--readonly", Dict(:help => "readonly query (default: false)", :action => "store_true"),
+        "--profile", Dict(:help => "config profile (default: default)"))
+    try
+        source = nothing
+        if !isnothing(args.command)
+            source = args.command
+        elseif !isnothing(args.file)
+            source = open(args.file, "r")
+        end
+        isnothing(source) && return  # nothing to execute
+        run(args.database, args.engine, source; profile = args.profile)
+    catch e
+        e isa HTTPError ? show(e) : rethrow()
+    end
+end
+
+main()

--- a/examples/exec_v1.jl
+++ b/examples/exec_v1.jl
@@ -21,7 +21,7 @@ include("parseargs.jl")
 function run(database, engine, source; profile)
     conf = load_config(; profile = profile)
     ctx = Context(conf)
-    rsp = exec(ctx, database, engine, source)
+    rsp = exec_v1(ctx, database, engine, source)
     show_result(rsp)
 end
 

--- a/examples/show-problems.jl
+++ b/examples/show-problems.jl
@@ -22,7 +22,8 @@ include("parseargs.jl")
 function run(database, engine; profile)
     conf = load_config(; profile = profile)
     ctx = Context(conf)
-    rsp = exec(ctx, database, engine, "def output = **nonsense**")
+    # TODO: rewrite via async + get_transaction_problems
+    rsp = exec_v1(ctx, database, engine, "def output = **nonsense**")
     show_problems(rsp)
 end
 

--- a/examples/show-result.jl
+++ b/examples/show-result.jl
@@ -31,7 +31,7 @@ using RAI: Context, HTTPError, exec, load_config, show_result
 include("parseargs.jl")
 
 const source = """
-def output = 
+def output =
     :drink, "martini", 2, 12.50, "2020-01-01";
     :drink, "sazerac", 4, 14.25, "2020-02-02";
     :drink, "cosmopolitan", 4, 11.00, "2020-03-03";
@@ -41,7 +41,7 @@ def output =
 function run(database, engine; profile)
     conf = load_config(; profile = profile)
     ctx = Context(conf)
-    rsp = exec(ctx, database, engine, source)
+    rsp = exec_v1(ctx, database, engine, source)
     show_result(rsp)
 end
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -354,6 +354,40 @@ end
 # todo: when we have async transactions, add a variation that dispatches and
 #   waits .. consider creating two entry points for readonly and readwrite.
 
+"""
+    exec(ctx, "database", "engine", "query source"; kwargs...)
+
+Synchronously execute a provided query string in the supplied database. This function
+creates a Transaction using the supplied engine, and then polls the Transaction until it has
+completed, and returns a Dict holding the Transaction resource and its results and metadata.
+
+## Keyword Arguments:
+- `readonly = false`: If true, this is a "read-only query", and the effects of this
+   transaction will not be committed to the database.
+- `inputs`: Optional dictionary of input pairs, mapping a relation name to a value.
+   (Deprecated - the format of the inputs Dict will change in upcoming releases.)
+
+# Examples:
+```julia
+julia> exec(ctx, "my_database", "my_engine", "2 + 2")
+Dict{String, Any} with 4 entries:
+  "metadata"    => Union{}[]
+  "problems"    => Union{}[]
+  "results"     => Pair{String, Arrow.Table}["/:output/Int64"=>Arrow.Table with 1 r…
+  "transaction" => {…
+
+julia> exec(ctx, "my_database", "my_engine", \"""
+           def insert:my_relation = 1, 2, 3
+           \""",
+           readonly = false,
+       )
+Dict{String, Any} with 4 entries:
+  "metadata"    => Union{}[]
+  "problems"    => Union{}[]
+  "results"     => Any[]
+  "transaction" => {…
+```
+"""
 function exec(ctx::Context, database::AbstractString, engine::AbstractString, source; inputs = nothing, readonly = false, kw...)
     txn = exec_async(ctx, database, engine, source; inputs=inputs, readonly=readonly, kw...)
     try

--- a/src/api.jl
+++ b/src/api.jl
@@ -357,7 +357,12 @@ end
 function exec(ctx::Context, database::AbstractString, engine::AbstractString, source; inputs = nothing, readonly = false, kw...)
     txn = exec_async(ctx, database, engine, source; inputs, readonly, kw...)
     try
-        backoff = Base.ExponentialBackOff(n=typemax(Int), first_delay=2, factor=2.0, max_delay=120) # 2 min
+        backoff = Base.ExponentialBackOff(
+                n = typemax(Int),
+                first_delay = 2,
+                factor = 1.2,
+                max_delay = 120,  # 2 min
+            )
         for duration in backoff
             transaction_is_done(txn) && break
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -355,7 +355,7 @@ end
 #   waits .. consider creating two entry points for readonly and readwrite.
 
 function exec(ctx::Context, database::AbstractString, engine::AbstractString, source; inputs = nothing, readonly = false, kw...)
-    txn = exec_async(ctx, database, engine, source; inputs, readonly, kw...)
+    txn = exec_async(ctx, database, engine, source; inputs=inputs, readonly=readonly, kw...)
     try
         backoff = Base.ExponentialBackOff(
                 n = typemax(Int),

--- a/src/api.jl
+++ b/src/api.jl
@@ -359,8 +359,8 @@ function exec(ctx::Context, database::AbstractString, engine::AbstractString, so
     try
         backoff = Base.ExponentialBackOff(
                 n = typemax(Int),
-                first_delay = 2,
-                factor = 1.2,
+                first_delay = 0.5,
+                factor = 1.1,
                 max_delay = 120,  # 2 min
             )
         for duration in backoff


### PR DESCRIPTION
Renames the old exec() function to exec_v1().

Uses the new sync exec() for load_csv and load_json! :)

---------

The "show_results" functionality still only works for the exec_v1 function's return values