### PR TITLE
Remove deprecated `persist=` option from v1 protocol wire format

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -294,7 +294,6 @@ function _make_query_action(source, ::Nothing)
     return Dict(
         "type" => "QueryAction",
         "source" => _make_query_source("query", source),
-        "persist" => [], # todo: remove
         "inputs" => [],
         "outputs" => [])
 end
@@ -303,7 +302,6 @@ function _make_query_action(source, inputs::Dict)
     return Dict(
         "type" => "QueryAction",
         "source" => _make_query_source("query", source),
-        "persist" => [], # todo: remove
         "inputs" => [_make_query_action_input(k, v) for (k, v) in inputs],
         "outputs" => [])
 end


### PR DESCRIPTION
~We should not be including this in any of the new SDKs. There's nothing
that can't be done without it, so it should always be safe to remove! :)~

~(Users should replace it with definitions for `insert:` instead.)~

EDIT: See below comment.