### PR TITLE
Revert "Remove deprecated `persist=` option from v1 protocol wire format"

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -294,6 +294,7 @@ function _make_query_action(source, ::Nothing)
     return Dict(
         "type" => "QueryAction",
         "source" => _make_query_source("query", source),
+        "persist" => [], # todo: remove
         "inputs" => [],
         "outputs" => [])
 end
@@ -302,6 +303,7 @@ function _make_query_action(source, inputs::Dict)
     return Dict(
         "type" => "QueryAction",
         "source" => _make_query_source("query", source),
+        "persist" => [], # todo: remove
         "inputs" => [_make_query_action_input(k, v) for (k, v) in inputs],
         "outputs" => [])
 end


### PR DESCRIPTION
Reverts RelationalAI/rai-sdk-julia#26

Whoops, looks like this was actually needed by the server in order to issue transactions. I guess I didn't run the examples, and was only relying on the unit tests, which don't actually exercise communication with the server. :)