### PR TITLE
new access token for each request

### DIFF
--- a/src/creds.jl
+++ b/src/creds.jl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-using Dates: DateTime
+using Dates: DateTime, Second
 
 struct AccessToken
     token::String
@@ -22,9 +22,8 @@ struct AccessToken
 end
 
 function isexpired(access_token::AccessToken)::Bool
-    expires_in = access_token.expires_in * 1000  # millis
-    expires_on = access_token.created_on + expires_in
-    return expires_on > now()
+    expires_on = access_token.created_on + Second(access_token.expires_in)
+    return expires_on < now()
 end
 
 abstract type Credentials end

--- a/src/rest.jl
+++ b/src/rest.jl
@@ -103,9 +103,7 @@ function _authenticate!(
     creds::ClientCredentials,
     headers::HTTP.Headers
 )::Nothing
-    if isnothing(creds.access_token)
-        creds.access_token = get_access_token(ctx, creds)
-    end
+    creds.access_token = get_access_token(ctx, creds)
     push!(headers, "Authorization" => "Bearer $(creds.access_token.token)")
     return nothing
 end

--- a/src/rest.jl
+++ b/src/rest.jl
@@ -103,7 +103,13 @@ function _authenticate!(
     creds::ClientCredentials,
     headers::HTTP.Headers
 )::Nothing
-    creds.access_token = get_access_token(ctx, creds)
+    if isnothing(creds.access_token)
+        creds.access_token = get_access_token(ctx, creds)
+    end
+
+    if isexpired(creds.access_token)
+        creds.access_token = get_access_token(ctx, creds)
+    end
     push!(headers, "Authorization" => "Bearer $(creds.access_token.token)")
     return nothing
 end


### PR DESCRIPTION
Creating a new access token for each request.
The best alternative is to check `access_token` expiration before renewing.