### PR TITLE
Adding extra headers support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## latest
 * Added `extraHeaders` support to the SDK. This could be used as following:
 ```
-create_engine(ctx, engine; size = size, extraHeaders=Dict{String, String}("x-rai-parameter-compute-version" => "....-rai-server-binary-linux"))
+create_engine(ctx, engine; size = size, headers=["x-rai-parameter-compute-version" => "....-rai-server-binary-linux"])
 ```
 
 ## v0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 * Add find_user to api.jl
 * Rename examples/get-userid.jl to examples/find-user.jl
-* Added `extraHeaders` support to the SDK. This could be used as following:
+* Fixed bug in support for custom extra `headers` in SDK. For example:
 ```
-create_engine(ctx, engine; size = size, headers=["x-rai-parameter-compute-version" => "....-rai-server-binary-linux"])
+create_engine(ctx, engine; size = size, headers=["my-custom-header" => "custom header value"])
 ```
 
 ## v0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## latest
+* Added `extraHeaders` support to the SDK. This could be used as following:
+```
+create_engine(ctx, engine; size = size, extraHeaders=Dict{String, String}("x-rai-parameter-compute-version" => "....-rai-server-binary-linux"))
+```
+
 ## v0.0.2
 * Added synchronous `exec()` function that polls the v2 `exec_async()` function until completion ([#25](https://github.com/RelationalAI/rai-sdk-julia/pull/25)).
     - Uses the "v2 protocol", so the transactions will show up in your transaction log.

--- a/src/rest.jl
+++ b/src/rest.jl
@@ -121,6 +121,8 @@ function request(
 )::HTTP.Response
     isnothing(body) && (body = UInt8[])
     _ensure_headers!(headers)
+    # Adding extra headers if present is kwargs
+    haskey(Dict(kw), :extraHeaders) && push!(headers, kw[:extraHeaders]...)
     _authenticate!(ctx, headers)
     opts = (redirect = false, retry = false)
     return HTTP.request(method, url, headers; query = query, body = body, opts..., kw...)

--- a/src/rest.jl
+++ b/src/rest.jl
@@ -121,7 +121,7 @@ function request(
 )::HTTP.Response
     isnothing(body) && (body = UInt8[])
     _ensure_headers!(headers)
-    # Adding extra headers if present is kwargs
+    # Adding extra headers if present in kwargs
     haskey(Dict(kw), :extraHeaders) && push!(headers, kw[:extraHeaders]...)
     _authenticate!(ctx, headers)
     opts = (redirect = false, retry = false)


### PR DESCRIPTION
This PR adds extra headers support to the current SDK.
The new feature could be used as below:
```
create_engine(ctx, engine; size = size, extraHeaders=Dict{String, String}("x-rai-parameter-compute-version" => "....-rai-server-binary-linux"))
```