### PR TITLE
Anticipate access token expiration

### DIFF
--- a/src/creds.jl
+++ b/src/creds.jl
@@ -23,7 +23,7 @@ end
 
 function isexpired(access_token::AccessToken)::Bool
     expires_on = access_token.created_on + Second(access_token.expires_in)
-    return expires_on < now()
+    return expires_on - Second(5) < now() # anticipate token expiration by 5 seconds
 end
 
 abstract type Credentials end


### PR DESCRIPTION
As requested from Martin, this PR should anticipate the access token expiration by couple of seconds to prevent scenarios where request is submitted exactly when token is expired.