### PR TITLE
Fix `headers=` kwarg so that user-supplied headers are respected

### DIFF
--- a/src/rest.jl
+++ b/src/rest.jl
@@ -64,6 +64,11 @@ function _user_agent()
 end
 
 # Ensures that the given headers contain the required values.
+function _ensure_headers!(h)
+    h = HTTP.Headers(h)
+    return _ensure_headers!(h)
+end
+
 function _ensure_headers!(h::HTTP.Headers = HTTP.Headers())::HTTP.Headers
     _haskeyfold(h, "accept") || push!(h, "Accept" => "application/json")
     _haskeyfold(h, "content-type") || push!(h, "Content-Type" => "application/json")
@@ -120,9 +125,7 @@ function request(
     headers = h, query = nothing, body = b, kw...
 )::HTTP.Response
     isnothing(body) && (body = UInt8[])
-    _ensure_headers!(headers)
-    # Adding extra headers if present in kwargs
-    haskey(Dict(kw), :extraHeaders) && push!(headers, kw[:extraHeaders]...)
+    headers = _ensure_headers!(headers)
     _authenticate!(ctx, headers)
     opts = (redirect = false, retry = false)
     return HTTP.request(method, url, headers; query = query, body = body, opts..., kw...)


### PR DESCRIPTION
@NRHelmi: I think this was always supposed to work, but there were some type infos in the code.

Before this PR, if you passed custom headers, they wouldn't work with `_ensure_headers!` because it required specifically `HTTP.Headers`, which is a `Vector{Pair{Substring,Substring}}`. I thought about loosening the type restriction to something like `AbstractVector`, but I decided to instead just convert the supplied headers to `HTTP.Headers` if it's not the right type.

I think this way we don't need to add another parameter, like you were trying in https://github.com/RelationalAI/rai-sdk-julia/pull/32?