### PR TITLE
Recent Engines now return a "metadata_info" part at the end that we need to deal with.

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -528,7 +528,10 @@ function _parse_multipart_fastpath_sync_response(msg)
     if results_start_idx === nothing
         results = []
     else
-        results = _extract_multipart_results_response(@view(parts[results_start_idx:end]))
+        has_metadata_info = last(parts).name == "metadata_info"
+        results_end_idx = has_metadata_info ? length(parts) - 1 : length(parts)
+        result_parts = @view(parts[results_start_idx:results_end_idx])
+        results = _extract_multipart_results_response(result_parts)
     end
 
     return Dict(


### PR DESCRIPTION
We were previously assuming all the last parts were results, but now we
need to check for the metadata info part at the end...

We're probably going to reverse this decision and instead return the
metadata.proto instead of the metadata.json depending on the requested
client version.