### PR TITLE
v2 show result

### DIFF
--- a/examples/exec_async.jl
+++ b/examples/exec_async.jl
@@ -30,7 +30,7 @@ function run(database, engine, source; profile)
     ctx = Context(conf)
     txn = exec_async(ctx, database, engine, source)
     println("Transaction is created...")
-    show(txn)
+    display(txn)
     println()
 end
 

--- a/examples/exec_async.jl
+++ b/examples/exec_async.jl
@@ -30,7 +30,7 @@ function run(database, engine, source; profile)
     ctx = Context(conf)
     txn = exec_async(ctx, database, engine, source)
     println("Transaction is created...")
-    display(txn)
+    show(txn)
     println()
 end
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -421,8 +421,12 @@ function exec(ctx::Context, database::AbstractString, engine::AbstractString, so
             m = @spawn get_transaction_metadata(ctx, id)
             p = @spawn get_transaction_problems(ctx, id)
             r = @spawn get_transaction_results(ctx, id)
-
-            return TransactionAsyncResult(fetch(t), fetch(m), fetch(p), fetch(r))
+            return Dict(
+                "transaction" => fetch(t),
+                "metadata" => fetch(m),
+                "problems" => fetch(p),
+                "results" => fetch(r),
+            )
         end
     catch
         @info "TXN" txn
@@ -518,14 +522,16 @@ function _parse_multipart_fastpath_sync_response(msg)
     @assert parts[1].name == "transaction"
     @assert parts[2].name == "metadata"
 
-    transaction = JSON3.read(parts[1])
-    metadata = JSON3.read(parts[2])
-
     problems_idx = findfirst(p->p.name == "problems", parts)
     problems = JSON3.read(parts[problems_idx])
     results = _extract_multipart_results_response(parts)
 
-    return TransactionAsyncResult(transaction, metadata, problems, results)
+    return Dict(
+        "transaction" => JSON3.read(parts[1]),
+        "metadata" => JSON3.read(parts[2]),
+        "problems" => problems,
+        "results" => results,
+    )
 end
 
 function _parse_multipart_results_response(msg)

--- a/src/api.jl
+++ b/src/api.jl
@@ -426,7 +426,7 @@ function exec(ctx::Context, database::AbstractString, engine::AbstractString, so
             return TransactionResponse(fetch(t), fetch(m), fetch(p), fetch(r))
         end
     catch
-        @info "TXN" txn
+        isdefined(txn) && @info "TXN" txn
         # Always print out the transaction id so that users can still get the txn ID even
         # if there's an error during polling (such as an InterruptException).
         #@info """Exception while polling for transaction:\n"id": $(repr(transaction_id(txn)))"""

--- a/src/results.jl
+++ b/src/results.jl
@@ -74,18 +74,17 @@ end
 
 function Base.show(io::IO, rsp::TransactionAsyncResult)
     out = (
-        :transaction => rsp.transaction,
-        :metadata => rsp.metadata,
-        :problems => rsp.problems,
-        :results => [
-            (res.first => [
-                (col => res.second[col])
-                    for col in keys(res.second)
-            ])
-                for res in rsp.results]
+        "transaction" => rsp.transaction,
+        "metadata" => rsp.metadata,
+        "problems" => rsp.problems,
+        "results" => rsp.results
     )
 
     show(io, out)
+end
+
+function Base.show(io::IO, table::Arrow.Table)
+    show(io, [(col => table[col]) for col in keys(table) ])
 end
 
 show_result(io::IO, rsp::JSON3.Object) = show(io, TransactionResult(rsp))

--- a/src/results.jl
+++ b/src/results.jl
@@ -81,7 +81,7 @@ function show_result(rsp::TransactionResponse)
 
     for index in 1:length(rsp.metadata)
         println(rsp.metadata[index]["relationId"])
-        println(collect(zip(rsp.results[index][2]))[1])
+        println(collect(zip(rsp.results[index]...)))
     end
 end
 

--- a/src/results.jl
+++ b/src/results.jl
@@ -58,6 +58,10 @@ function Base.show(io::IO, result::TransactionResult)
     show_problems(result)
 end
 
+function Base.show(io::IO, table::Arrow.Table)
+    show(io, [(col => table[col]) for col in keys(table) ])
+end
+
 show_result(io::IO, rsp::JSON3.Object) = show(io, TransactionResult(rsp))
 show_result(rsp::JSON3.Object) = show(stdout, TransactionResult(rsp))
 

--- a/src/results.jl
+++ b/src/results.jl
@@ -22,20 +22,6 @@ struct TransactionResult
     _data::JSON3.Object
 end
 
-struct TransactionAsyncResult
-    transaction::JSON3.Object
-    metadata::JSON3.Array
-    problems::JSON3.Array
-    results::Vector{Pair{String, Arrow.Table}}
-
-    TransactionAsyncResult(
-        transaction::JSON3.Object,
-        metadata::JSON3.Array,
-        problems::JSON3.Array,
-        results::Any
-    ) = new(transaction, metadata, problems, results)
-end
-
 _data(result::TransactionResult) = getfield(result, :_data)
 
 Base.getindex(result::TransactionResult, key) = _data(result)[key]
@@ -72,26 +58,8 @@ function Base.show(io::IO, result::TransactionResult)
     show_problems(result)
 end
 
-function Base.show(io::IO, rsp::TransactionAsyncResult)
-    out = (
-        "transaction" => rsp.transaction,
-        "metadata" => rsp.metadata,
-        "problems" => rsp.problems,
-        "results" => rsp.results
-    )
-
-    show(io, out)
-end
-
-function Base.show(io::IO, table::Arrow.Table)
-    show(io, [(col => table[col]) for col in keys(table) ])
-end
-
 show_result(io::IO, rsp::JSON3.Object) = show(io, TransactionResult(rsp))
 show_result(rsp::JSON3.Object) = show(stdout, TransactionResult(rsp))
-
-show_result(io::IO, rsp::TransactionAsyncResult) = show(io, rsp)
-show_result(rsp::TransactionAsyncResult) = show(stdout, rsp)
 
 """
     show_problems([io::IO], rsp)

--- a/src/results.jl
+++ b/src/results.jl
@@ -15,7 +15,6 @@
 # Functions for accessing transaction results, including an implementation
 # of the Tables.jl interfaces.
 
-
 import JSON3
 import Tables
 

--- a/src/results.jl
+++ b/src/results.jl
@@ -26,14 +26,14 @@ struct TransactionAsyncResult
     transaction::JSON3.Object
     metadata::JSON3.Array
     problems::JSON3.Array
-    result::Vector{Pair{String, Arrow.Table}}
+    results::Vector{Pair{String, Arrow.Table}}
 
     TransactionAsyncResult(
         transaction::JSON3.Object,
         metadata::JSON3.Array,
         problems::JSON3.Array,
-        result::Any
-    ) = new(transaction, metadata, problems, result)
+        results::Any
+    ) = new(transaction, metadata, problems, results)
 end
 
 _data(result::TransactionResult) = getfield(result, :_data)
@@ -77,12 +77,12 @@ function Base.show(io::IO, rsp::TransactionAsyncResult)
         :transaction => rsp.transaction,
         :metadata => rsp.metadata,
         :problems => rsp.problems,
-        :result => [
+        :results => [
             (res.first => [
                 (col => res.second[col])
                     for col in keys(res.second)
             ])
-                for res in rsp.result]
+                for res in rsp.results]
     )
 
     show(io, out)

--- a/src/results.jl
+++ b/src/results.jl
@@ -75,13 +75,23 @@ end
 show_result(io::IO, rsp::JSON3.Object) = show(io, TransactionResult(rsp))
 show_result(rsp::JSON3.Object) = show(stdout, TransactionResult(rsp))
 
-function show_result(rsp::TransactionResponse)
+show_result(rsp::TransactionResponse) = show_result(stdout, rsp)
+function show_result(io::IO, rsp::TransactionResponse)
     rsp.metadata === nothing && return
     rsp.results === nothing && return
 
-    for index in 1:length(rsp.metadata)
-        println(rsp.metadata[index]["relationId"])
-        println(collect(zip(rsp.results[index]...)))
+    for index in eachindex(rsp.metadata)
+        println(io, rsp.metadata[index]["relationId"])
+        tuples = zip(rsp.results[index][2]...)
+        # Reuse julia's array printing function to print this array of tuples.
+        Base.print_array(io, collect(tuples))
+
+        # Print trailing newline
+        if index !== last(eachindex(rsp.metadata))
+            println(io, "\n")
+        else
+            println(io, "")
+        end
     end
 end
 

--- a/test/api.jl
+++ b/test/api.jl
@@ -3,6 +3,8 @@ using Test
 import HTTP, Arrow
 using Mocking
 
+using RAI: TransactionResponse
+
 Mocking.activate()
 
 # -----------------------------------
@@ -124,5 +126,21 @@ end
             @test !isempty(rsp)
             @test rsp[1][2] isa Arrow.Table
         end
+    end
+end
+
+@testset "show_result" begin
+    ctx = Context("region", "scheme", "host", "2342", nothing)
+    patch = make_patch(v2_fastpath_response)
+
+    apply(patch) do
+        rsp = RAI.exec_async(ctx, "engine", "database", "2+2")
+        @test rsp isa TransactionResponse
+
+        io = IOBuffer()
+        show_result(io, rsp)
+        @test String(take!(io)) === """/:output/Int64
+         (4,)
+        """
     end
 end

--- a/test/api.jl
+++ b/test/api.jl
@@ -84,9 +84,7 @@ end
 
         apply(patch) do
             rsp = RAI.exec_async(ctx, "engine", "database", "2+2")
-            @test rsp == Dict(
-                "transaction" => JSON3.read("""{"id":"1fc9001b-1b88-8685-452e-c01bc6812429","state":"CREATED"}""")
-            )
+            @test rsp.transaction == JSON3.read("""{"id":"1fc9001b-1b88-8685-452e-c01bc6812429","state":"CREATED"}""")
         end
     end
 

--- a/test/api.jl
+++ b/test/api.jl
@@ -95,26 +95,26 @@ end
 
         apply(patch) do
             rsp = RAI.exec_async(ctx, "engine", "database", "2+2")
-            @test rsp.transaction == JSON3.read("""{
+            @test rsp["transaction"] == JSON3.read("""{
                     "id": "a3e3bc91-0a98-50ba-733c-0987e160eb7d",
                     "results_format_version": "2.0.1",
                     "state": "COMPLETED"
                 }""")
-            @test rsp.metadata == [JSON3.read("""{
+            @test rsp["metadata"] == [JSON3.read("""{
                 "relationId": "/:output/Int64",
                     "types": [
                                 ":output",
                                 "Int64"
                             ]
             }""")]
-            @test rsp.problems == Union{}[]
+            @test rsp["problems"] == Union{}[]
 
             # Test for the expected arrow data:
             expected_data = make_arrow_table([4])
             # Arrow.Tables can't be compared via == (https://github.com/apache/arrow-julia/issues/310)
-            @test length(rsp.results) == 1
-            @test rsp.results[1][1] == "/:output/Int64"
-            @test collect(rsp.results[1][2]) == collect(expected_data)
+            @test length(rsp["results"]) == 1
+            @test rsp["results"][1][1] == "/:output/Int64"
+            @test collect(rsp["results"][1][2]) == collect(expected_data)
         end
     end
 

--- a/test/api.jl
+++ b/test/api.jl
@@ -95,26 +95,26 @@ end
 
         apply(patch) do
             rsp = RAI.exec_async(ctx, "engine", "database", "2+2")
-            @test rsp["transaction"] == JSON3.read("""{
+            @test rsp.transaction == JSON3.read("""{
                     "id": "a3e3bc91-0a98-50ba-733c-0987e160eb7d",
                     "results_format_version": "2.0.1",
                     "state": "COMPLETED"
                 }""")
-            @test rsp["metadata"] == [JSON3.read("""{
+            @test rsp.metadata == [JSON3.read("""{
                 "relationId": "/:output/Int64",
                     "types": [
                                 ":output",
                                 "Int64"
                             ]
             }""")]
-            @test rsp["problems"] == Union{}[]
+            @test rsp.problems == Union{}[]
 
             # Test for the expected arrow data:
             expected_data = make_arrow_table([4])
             # Arrow.Tables can't be compared via == (https://github.com/apache/arrow-julia/issues/310)
-            @test length(rsp["results"]) == 1
-            @test rsp["results"][1][1] == "/:output/Int64"
-            @test collect(rsp["results"][1][2]) == collect(expected_data)
+            @test length(rsp.results) == 1
+            @test rsp.results[1][1] == "/:output/Int64"
+            @test collect(rsp.results[1][2]) == collect(expected_data)
         end
     end
 


### PR DESCRIPTION
This PR adds support to v2 `show_result`
Closes https://github.com/RelationalAI/rai-sdk-julia/issues/38

```julia
julia> txn = RAI.exec(ctx, db, eng, "def a = 1;2 def b = 3;4 def output:one = a def output:two = b")
RAI.TransactionResponse({
                        "id": "81d81b7f-f636-6eb5-050c-b3538cc78986",
              "account_name": "relationalai-team-rd-flex",
                     "state": "COMPLETED",
                "created_by": "HZON00cfTWiDZBdQkU627DpJfTPOAgjM@clients",
                "created_on": 1657302573392,
             "database_name": "nhd-empty-2",
                 "read_only": false,
               "engine_name": "nhd-S-2",
                     "query": "def a = 1;2 def b = 3;4 def output:one = a def output:two = b",
                      "tags": [],
                "user_agent": "rai-sdk-julia/0.0.1",
   "last_requested_interval": 0,
   "response_format_version": "2.0.3"
}, JSON3.Object[{
   "relationId": "/:output/:two/Int64",
        "types": [
                   ":output",
                   ":two",
                   "Int64"
                 ]
}, {
   "relationId": "/:output/:one/Int64",
        "types": [
                   ":output",
                   ":one",
                   "Int64"
                 ]
}], Union{}[], Pair{String, Arrow.Table}["/:output/:two/Int64" => Arrow.Table with 2 rows, 1 columns, and schema:
 :v1  Int64, "/:output/:one/Int64" => Arrow.Table with 2 rows, 1 columns, and schema:
 :v1  Int64])

julia> RAI.show_result(txn)
/:output/:two/Int64
 (3,)
 (4,)

/:output/:one/Int64
 (1,)
 (2,)

julia>
```