### PR TITLE
Add support for optional `audience` field to Config

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -21,6 +21,7 @@ mutable struct Config
     host::Union{String,Nothing}
     port::Union{String,Nothing}
     credentials::Union{Credentials,Nothing}
+    audience::Union{String,Nothing}
 end
 
 function _load_stanza(fname::AbstractString, profile::AbstractString)
@@ -43,10 +44,11 @@ function load_config(; fname = nothing, profile = nothing)::Config
     port = _get_value(stanza, "port")
     client_id = _get_value(stanza, "client_id")
     client_secret = _get_value(stanza, "client_secret")
+    audience = _get_value(stanza, "audience")
     credentials = nothing
     if !isnothing(client_id) && !isnothing(client_secret)
         client_credentials_url = _get_value(stanza, "client_credentials_url")
         credentials = ClientCredentials(client_id, client_secret, client_credentials_url)
     end
-    return Config(region, scheme, host, port, credentials)
+    return Config(region, scheme, host, port, credentials, audience)
 end

--- a/test/api.jl
+++ b/test/api.jl
@@ -89,7 +89,7 @@ end
 end
 
 @testset "exec_async" begin
-    ctx = Context("region", "scheme", "host", "2342", nothing)
+    ctx = Context("region", "scheme", "host", "2342", nothing, "audience")
 
     @testset "async response" begin
         patch = make_patch(v2_async_response)
@@ -140,7 +140,7 @@ end
 end
 
 @testset "show_result" begin
-    ctx = Context("region", "scheme", "host", "2342", nothing)
+    ctx = Context("region", "scheme", "host", "2342", nothing, "audience")
     patch = make_patch(v2_fastpath_response)
 
     apply(patch) do
@@ -169,7 +169,7 @@ function make_fail_second_time_patch(first_response, fail_code)
 end
 
 @testset "error handling" begin
-    ctx = Context("region", "scheme", "host", "2342", nothing)
+    ctx = Context("region", "scheme", "host", "2342", nothing, "audience")
     patch = @patch RAI.request(ctx::Context, args...; kw...) = throw(NetworkError(404))
 
     apply(patch) do
@@ -197,7 +197,7 @@ end
     only_1_request_patch = Mocking.Patch(RAI.request,
         make_fail_second_time_patch(v2_fastpath_response, 500))
 
-    ctx = Context("region", "scheme", "host", "2342", nothing)
+    ctx = Context("region", "scheme", "host", "2342", nothing, "audience")
     apply(only_1_request_patch) do
         @test RAI.exec(ctx, "engine", "db", "2+2") isa RAI.TransactionResponse
     end

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -10,7 +10,22 @@ import UUIDs
 const POLLING_KWARGS =
     (:n => 14, :first_delay => 1.0, :factor => 1.6, :throw_on_max_n => true)
 
-function test_context()
+function test_context(profile_name = nothing)
+    # If the ENV isn't configured for testing (local development), try using the local
+    # Config file!
+    if !haskey(ENV, "CLIENT_ID")
+        if isfile(homedir()*"/.rai/config")
+            if profile_name !== nothing
+                cfg = load_config(; profile = profile_name)
+            else
+                cfg = load_config()
+            end
+            return Context(cfg)
+        end
+    end
+
+    # Otherwise, we are testing using the secrets specified in ENV variables.
+
     @assert all(
         key -> haskey(ENV, key),
         ["CLIENT_ID", "CLIENT_SECRET", "CLIENT_CREDENTIALS_URL"],

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -19,9 +19,10 @@ function test_context()
     client_id = ENV["CLIENT_ID"]
     client_secret = ENV["CLIENT_SECRET"]
     client_credentials_urls = ENV["CLIENT_CREDENTIALS_URL"]
+    audience = get(ENV, "CLIENT_AUDIENCE", nothing)
 
     credentials = ClientCredentials(client_id, client_secret, client_credentials_urls)
-    config = Config("us-east", "https", "azure.relationalai.com", "443", credentials)
+    config = Config("us-east", "https", "azure.relationalai.com", "443", credentials, audience)
 
     return Context(config)
 end
@@ -107,7 +108,7 @@ with_engine(CTX) do engine_name
                 txn = resp.transaction
 
                 @test txn[:state] == "COMPLETED"
-                txn_id = transaction_id(txn) 
+                txn_id = transaction_id(txn)
 
                 _poll_until(; POLLING_KWARGS...) do
                     RAI.transaction_is_done(get_transaction(CTX, txn_id))
@@ -175,7 +176,7 @@ with_engine(CTX) do engine_name
         end
 
         # -----------------------------------
-        # models 
+        # models
         @testset "models" begin end
     end
 end
@@ -193,5 +194,5 @@ end
 @testset "oauth" begin end
 
 # -----------------------------------
-# users 
+# users
 @testset "users" begin end

--- a/test/rest.jl
+++ b/test/rest.jl
@@ -4,7 +4,7 @@ using RAI
 import HTTP
 
 @testset "custom headers" begin
-    ctx = Context("us-east", "https", "host", "2342", nothing)
+    ctx = Context("us-east", "https", "host", "2342", nothing, "audience")
     rsp = RAI.request(ctx, "GET", "https://www.example.com", headers = ["test" => "value"])
     @test rsp isa HTTP.Response
 end


### PR DESCRIPTION
This adds the same support to the Julia SDK that was added to Python and
Go's SDKs, e.g. in:
https://github.com/RelationalAI/rai-sdk-python/pull/69

This allows us to test development of the RAI Engines with the public
RAI SDK, by using a non-hosted engine.