### PR TITLE
v2 create_database (nonbreaking, with backwards compatible deprecation)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RAI"
 uuid = "9c30249a-7e08-11ec-0e99-a323e937e79f"
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/src/api.jl
+++ b/src/api.jl
@@ -394,7 +394,7 @@ function create_database(
     overwrite = false,
     kw...
 )
-    ### Deprecation warnings: remove these parameters and warnings in a future release. ###
+    ### Deprecation support: remove these parameters and warnings in a future release. ###
     if !isempty(engine)
         @warn """DEPRECATED: Passing an `engine` is no longer required for creating a \
             database. This will be removed in a future release. Please update your call to \
@@ -405,10 +405,17 @@ function create_database(
             database. This will be removed in a future release. Please delete an existing \
             database before attempting to create it."""
         @assert engine !== "" "`overwrite` is not supported in the new engineless API."
+    end
+    if !isempty(engine) || overwrite == true
+        # If they were calling via the old API, continue to call the old method, to prevent
+        # a breaking change in the return value format.
         return _create_database_v1(ctx, database, engine; source, overwrite, kw...)
     end
-    ### End deprecation warnings ##########################################################
-    data = Dict("name" => database, "source_name" => source)
+    ### End deprecation support ##########################################################
+    data = Dict("name" => database)
+    if source !== nothing
+        data["source_name"] = source
+    end
     return _put(ctx, PATH_DATABASE; body = JSON3.write(data), kw...)
 end
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -396,14 +396,14 @@ function create_database(
 )
     ### Deprecation support: remove these parameters and warnings in a future release. ###
     if !isempty(engine)
-        @warn """DEPRECATED: Passing an `engine` is no longer required for creating a \
-            database. This will be removed in a future release. Please update your call to \
-            `create_database(ctx, name)`."""
+        @warn "DEPRECATED: Passing an `engine` is no longer required for creating a" *
+            " database. This will be removed in a future release. Please update your call" *
+            " `create_database(ctx, name)`."
     end
     if overwrite == true
-        @warn """DEPRECATED: The `overwrite` option is no longer supported for creating a \
-            database. This will be removed in a future release. Please delete an existing \
-            database before attempting to create it."""
+        @warn "DEPRECATED: The `overwrite` option is no longer supported for creating a" *
+            " database. This will be removed in a future release. Please delete an" *
+            " existing database before attempting to create it."
         @assert engine !== "" "`overwrite` is not supported in the new engineless API."
     end
     if !isempty(engine) || overwrite == true

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -1,3 +1,4 @@
+using Test
 using RAI
 using RAI: transaction_id, _poll_until
 

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -84,6 +84,9 @@ function with_database(f, ctx, engine_name; existing_database=nothing)
     end
 end
 
+# If the env vars are not properly set this will fail!
+const CTX = test_context()
+
 # -----------------------------------
 # engine
 @testset "engine" begin end
@@ -122,9 +125,6 @@ end
 
 # -----------------------------------
 # transactions
-
-# If the env vars are not properly set this will fail!
-CTX = test_context()
 
 with_engine(CTX) do engine_name
     with_database(CTX, engine_name) do database_name

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -84,6 +84,45 @@ function with_database(f, ctx, engine_name; existing_database=nothing)
     end
 end
 
+# -----------------------------------
+# engine
+@testset "engine" begin end
+
+# -----------------------------------
+# database
+@testset "database" begin
+    dbname = rnd_test_name()
+    rsp = create_database(CTX, dbname)
+    @test rsp.database.name == dbname
+    @test rsp.database.state == "CREATED"
+
+    # TODO: https://github.com/RelationalAI/relationalai-infra/issues/2542
+    # In order to clone from a database, you currently need to "touch" it, to materialize
+    # it. Remove this once that is fixed.
+    with_engine(CTX) do engine_name
+        _ = exec(CTX, dbname, engine_name, "")
+    end
+
+    dbname_clone = "$dbname-clone"
+    rsp = create_database(CTX, dbname_clone, source=dbname)
+    @test rsp.database.name == dbname_clone
+    @test rsp.database.state == "CREATED"
+
+    # Already exists
+    @test_throws RAI.HTTPError create_database(CTX, dbname_clone)
+    @test_throws RAI.HTTPError create_database(CTX, dbname_clone, source=dbname)
+
+    rsp = delete_database(CTX, dbname)
+    @test rsp.name == dbname
+    @test delete_database(CTX, dbname_clone).name == dbname_clone
+
+    # Doesn't exists
+    @test_throws RAI.HTTPError delete_database(CTX, dbname)
+end
+
+# -----------------------------------
+# transactions
+
 # If the env vars are not properly set this will fail!
 CTX = test_context()
 
@@ -196,14 +235,6 @@ with_engine(CTX) do engine_name
         @testset "models" begin end
     end
 end
-
-# -----------------------------------
-# engine
-@testset "engine" begin end
-
-# -----------------------------------
-# database
-@testset "database" begin end
 
 # -----------------------------------
 # client


### PR DESCRIPTION
Implement v2 `create_database()`, which drops the requirement to pass in an engine:
```julia
julia> ctx = Context(load_config())
Context("us-east", "https", "azure.relationalai.com", "443", ClientCredentials("HZON00cfTWiDZBdQkU627DpJfTPOAgjM", "OkZaHX-YuLepzV4QkCQcKjVPZI1fz3AraCBCaNvNZULcxY6Jk6pZZkzZBBhkN0AR", nothing, nothing), "https://azure.relationalai.com")

julia> create_database(ctx, "mytestdb")
JSON3.Object{Vector{UInt8}, Vector{UInt64}} with 1 entry:
  :database => {…

julia> show(ans)
{
   "database": {
                  "account_name": "relationalai-team-rd-flex",
                          "name": "mytestdb",
                            "id": "494db1da-aaa6-a08d-81ae-a585abdecf56",
                         "state": "CREATED",
                        "region": "us-east",
                    "created_on": "2022-08-09T19:02:08.147Z",
                    "created_by": "HZON00cfTWiDZBdQkU627DpJfTPOAgjM@clients"
               }
}
```
(i really hate the way JSON objects display in julia)

But maintain backwards compatibility with the old function call, and display a DEPRECATION warning:
```julia
julia> create_database(ctx, "mytestdb", "dba-playground", overwrite=true)
┌ Warning: DEPRECATED: Passing an `engine` is no longer required for creating a database. This will be removed in a future release. Please update your call to `create_database(ctx, name)`.
└ @ RAI ~/work/rai-sdk-julia/src/api.jl:399
┌ Warning: DEPRECATED: The `overwrite` option is no longer supported for creating a database. This will be removed in a future release. Please delete an existing database before attempting to create it.
└ @ RAI ~/work/rai-sdk-julia/src/api.jl:404
JSON3.Object{Vector{UInt8}, Vector{UInt64}} with 7 entries:
  :output       => Union{}[]
  :problems     => Union{}[]
  :actions      => Union{}[]
  :debug_level  => 0
  :aborted      => false
  :type         => "TransactionResult"
  :abort_reason => nothing
```

The new return format is different than the old return format, but as long as you call through the old API (by passing an engine) you will still get the old return format for now.

The next release can be a breaking release that drops support for the old API call.

Fixes https://github.com/RelationalAI/rai-sdk-julia/issues/57.