### PR TITLE
Implement fixed-overhead polling; add `wait_until_done()` for Transactions

### DIFF
--- a/src/RAI.jl
+++ b/src/RAI.jl
@@ -73,6 +73,7 @@ export
 export
     exec,
     exec_async,
+    wait_until_done,
     list_edbs,
     load_csv,
     load_json
@@ -95,6 +96,7 @@ export
 include("creds.jl")
 include("config.jl")
 include("rest.jl")
+include("response.jl")
 include("api.jl")
 include("results.jl")
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -100,10 +100,12 @@ function wait_until_done(ctx::Context, id::AbstractString; start_time_ns = nothi
     end
 end
 
-# Polls until the execution `f()` is truthy or the maximum number of polls is
-# reached. Polling frequency is controlled to minimize overhead, by keeping the overhead
-# from sleeping within a specified overhead rate. If `throw_on_max_n` is set to true, this
-# will throw if the maximum number of iterations are reached.
+# Polls until the execution `f()` is truthy or the maximum number of polls is reached.
+# Polling frequency is computed to minimize overhead: we carefully set the sleep time
+# between polls to a fraction of the time waited so far, so that after any given sleep, we
+# cannot have missed the upstream result by more than `overhead_rate` of the _actual time_.
+# If `throw_on_max_n` is set to true, this will throw if the maximum number of iterations
+# are reached.
 function _poll_with_specified_overhead(
     f;
     overhead_rate,  # Add xx% overhead through polling.

--- a/src/api.jl
+++ b/src/api.jl
@@ -86,7 +86,7 @@ function wait_until_done(ctx::Context, id::AbstractString; start_time_ns = nothi
         start_time_ns = _transaction_start_time_ns(txn)
     end
     try
-        _poll_with_specified_overhead(; overhead_rate = 0.05, start_time_ns) do
+        _poll_with_specified_overhead(; overhead_rate = 0.10, start_time_ns) do
             txn = get_transaction(ctx, id)
             return transaction_is_done(txn)
         end

--- a/src/api.jl
+++ b/src/api.jl
@@ -82,7 +82,7 @@ function wait_until_done(ctx::Context, id::AbstractString; start_time_ns = nothi
         start_time_ns = Dates.unix2datetime(unix_ms)
     end
     try
-        _poll_with_specified_overhead(; overhead_rate = 0.01, start_time_ns) do
+        _poll_with_specified_overhead(; overhead_rate = 0.05, start_time_ns) do
             txn = get_transaction(ctx, id)
             return transaction_is_done(txn)
         end

--- a/src/response.jl
+++ b/src/response.jl
@@ -1,0 +1,9 @@
+using Arrow
+
+struct TransactionResponse
+    transaction::JSON3.Object
+    metadata::Union{JSON3.Array,Nothing}
+    problems::Union{JSON3.Array,Nothing}
+    results::Union{Vector{Pair{String, Arrow.Table}},Nothing}
+end
+

--- a/src/results.jl
+++ b/src/results.jl
@@ -22,20 +22,6 @@ struct TransactionResult
     _data::JSON3.Object
 end
 
-struct TransactionResponse
-    transaction::JSON3.Object
-    metadata::Union{JSON3.Array,Nothing}
-    problems::Union{JSON3.Array,Nothing}
-    results::Union{Vector{Pair{String, Arrow.Table}},Nothing}
-
-    TransactionResponse(
-        transaction::JSON3.Object,
-        metadata::Union{JSON3.Array,Nothing},
-        problems::Union{JSON3.Array,Nothing},
-        results::Union{Vector{Pair{String, Arrow.Table}},Nothing}
-    ) = new(transaction, metadata, problems, results)
-end
-
 _data(result::TransactionResult) = getfield(result, :_data)
 
 Base.getindex(result::TransactionResult, key) = _data(result)[key]

--- a/test/api.jl
+++ b/test/api.jl
@@ -84,8 +84,8 @@ end
     @test isnothing(_poll_with_specified_overhead(() -> true; overhead_rate = 0.01))
     @test isnothing(_poll_with_specified_overhead(() -> false; overhead_rate = 0.01, n=0))
     @test isnothing(_poll_with_specified_overhead(() -> false; overhead_rate = 0.01, n=1))
-    @test isnothing(_poll_with_specified_overhead(() -> true; overhead_rate = 0.01, n=1, throw_on_max_n=true))
-    @test_throws ErrorException _poll_with_specified_overhead(() -> false; overhead_rate = 0.01, n=1, throw_on_max_n=true)
+    @test isnothing(_poll_with_specified_overhead(() -> true; overhead_rate = 0.01, n=1, throw_on_timeout=true))
+    @test_throws ErrorException _poll_with_specified_overhead(() -> false; overhead_rate = 0.01, n=1, throw_on_timeout=true)
 end
 
 @testset "exec_async" begin

--- a/test/api.jl
+++ b/test/api.jl
@@ -3,7 +3,7 @@ using Test
 import HTTP, Arrow
 using JSON3
 using Mocking
-using RAI: _poll_until
+using RAI: _poll_with_specified_overhead
 
 using RAI: TransactionResponse
 
@@ -80,12 +80,12 @@ function make_arrow_table(vals)
     return Arrow.Table(io)
 end
 
-@testset "_poll_until" begin
-    @test isnothing(_poll_until(() -> true))
-    @test isnothing(_poll_until(() -> false; n=0))
-    @test isnothing(_poll_until(() -> false; n=1))
-    @test isnothing(_poll_until(() -> true; n=1, throw_on_max_n=true))
-    @test_throws String _poll_until(() -> false; n=1, throw_on_max_n=true)
+@testset "_poll_with_specified_overhead" begin
+    @test isnothing(_poll_with_specified_overhead(() -> true; overhead_rate = 0.01))
+    @test isnothing(_poll_with_specified_overhead(() -> false; overhead_rate = 0.01, n=0))
+    @test isnothing(_poll_with_specified_overhead(() -> false; overhead_rate = 0.01, n=1))
+    @test isnothing(_poll_with_specified_overhead(() -> true; overhead_rate = 0.01, n=1, throw_on_max_n=true))
+    @test_throws ErrorException _poll_with_specified_overhead(() -> false; overhead_rate = 0.01, n=1, throw_on_max_n=true)
 end
 
 @testset "exec_async" begin
@@ -188,8 +188,8 @@ end
         end
     end
     sym, val = collect(pairs(logs[1].kwargs))[1]
-    @test sym ≡ :transaction
-    @test val == JSON3.read("""{"id":"1fc9001b-1b88-8685-452e-c01bc6812429","state":"CREATED"}""")
+    @test sym ≡ :transaction_id
+    @test val == "1fc9001b-1b88-8685-452e-c01bc6812429"
 end
 
 @testset "exec with fast-path response only makes one request" begin

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -8,8 +8,8 @@ import UUIDs
 # context & setup
 
 # These are fairly unaggressive testing parameters, to try to not be too expensive on the
-# cloud. This should timeout after around 5 minutes of silence.
-const POLLING_KWARGS = (; overhead_rate = 0.20, n = 25, throw_on_max_n = true)
+# cloud. Time out after ten minutes of silence.
+const POLLING_KWARGS = (; overhead_rate = 0.20, timeout_secs = 10*60, throw_on_timeout = true)
 
 function test_context(profile_name = nothing)
     # If the ENV isn't configured for testing (local development), try using the local

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -173,6 +173,14 @@ with_engine(CTX) do engine_name
                 # transaction
                 @test RAI.transaction_is_done(get_transaction(CTX, txn_id))
 
+                # Test calling this after the transaction already _is_ done:
+                wait_until_done(CTX, txn_id)
+                # Test all the API variants:
+                wait_until_done(CTX, txn_id)
+                wait_until_done(CTX, txn)
+                wait_until_done(CTX, resp)
+                wait_until_done(CTX, get_transaction(CTX, txn_id))
+
                 # metadata
                 # TODO (dba): Test new ProtoBuf metadata.
 


### PR DESCRIPTION
- Implement the fixed (~1%~ ~5%~ 10%) overhead polling algorithm.
- Add a user-facing `wait_until_done(txn)` function.
- Implement `exec()` in terms of `exec_async()` + `wait_until_done()`.
- Update tests

This implements the polling algorithm we discussed at Monday's API meeting:
https://github.com/RelationalAI/rai-sdk-issues/issues/58
> One way to approach this is "wait 1% of the time the transaction has been running so far", then exec() adds at most 1% to the duration of the transaction. With the above backoff if I'm reading it correctly you double the duration of transactions that take slightly more than 0.5 seconds, and it falls off gradually e.g. add 20% to transactions that take 5 seconds.
