### PR TITLE
Fix show_result for schema-only relation values (e.g. `def output = true`)

### DIFF
--- a/src/results.jl
+++ b/src/results.jl
@@ -82,7 +82,8 @@ function show_result(io::IO, rsp::TransactionResponse)
 
     for index in eachindex(rsp.metadata)
         println(io, rsp.metadata[index]["relationId"])
-        tuples = zip(rsp.results[index][2]...)
+        data = rsp.results[index][2]
+        tuples = isempty(data) ? [()] : zip(data...)
         # Reuse julia's array printing function to print this array of tuples.
         Base.print_array(io, collect(tuples))
 

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -228,6 +228,33 @@ with_engine(CTX) do engine_name
             @testset "load_json" begin end
 
             @testset "list_edb" begin end
+
+            @testset "show_result" begin
+                function show_result_str(rsp)
+                    io = IOBuffer()
+                    show_result(io, rsp)
+                    return String(take!(io))
+                end
+                @testset "empty arrow file"
+                    query_string = "def output = true"
+                    resp = exec(CTX, database_name, engine_name, query_string)
+                    @test show_result_str(resp) === """/:output
+                     ()
+                    """
+                end
+                @testset "multiple physical relations"
+                    query_string = ":a, 1;  :b, 2,3;  :b, 4,5"
+                    resp = exec(CTX, database_name, engine_name, query_string)
+                    @test show_result_str(resp) === """/:output/:a/Int64
+                     (1,)
+
+                    /:output/:b/Int64/Int64
+                     (2, 3)
+                     (4, 5)
+                    """
+                end
+            end
+
         end
 
         # -----------------------------------

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -235,14 +235,14 @@ with_engine(CTX) do engine_name
                     show_result(io, rsp)
                     return String(take!(io))
                 end
-                @testset "empty arrow file"
+                @testset "empty arrow file" begin
                     query_string = "def output = true"
                     resp = exec(CTX, database_name, engine_name, query_string)
                     @test show_result_str(resp) === """/:output
                      ()
                     """
                 end
-                @testset "multiple physical relations"
+                @testset "multiple physical relations" begin
                     query_string = ":a, 1;  :b, 2,3;  :b, 4,5"
                     resp = exec(CTX, database_name, engine_name, query_string)
                     @test show_result_str(resp) === """/:output/:a/Int64


### PR DESCRIPTION
- Adds show_result integration tests
- fixes show_result for relations with an empty body.