### PR TITLE
Pfl windows safe homedir

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -35,7 +35,7 @@ end
 _get_value(d::Dict, k::String) = first(get(d, k, (nothing,)))
 
 function load_config(; fname = nothing, profile = nothing)::Config
-    isnothing(fname) && (fname = "~/.rai/config")
+    isnothing(fname) && (fname = homedir() * "/.rai/config")
     isnothing(profile) && (profile = "default")
     stanza = _load_stanza(fname, profile)
     region = _get_value(stanza, "region")

--- a/src/config.jl
+++ b/src/config.jl
@@ -35,7 +35,7 @@ end
 _get_value(d::Dict, k::String) = first(get(d, k, (nothing,)))
 
 function load_config(; fname = nothing, profile = nothing)::Config
-    isnothing(fname) && (fname = homedir() * "/.rai/config")
+    isnothing(fname) && (fname = joinpath(homedir(), ".rai", "config"))
     isnothing(profile) && (profile = "default")
     stanza = _load_stanza(fname, profile)
     region = _get_value(stanza, "region")

--- a/test/config.jl
+++ b/test/config.jl
@@ -1,0 +1,7 @@
+using RAI
+using Test
+
+@testset "config creation" begin
+    conf = load_config()
+    @test conf isa RAI.Config 
+end

--- a/test/config.jl
+++ b/test/config.jl
@@ -2,6 +2,8 @@ using RAI
 using Test
 
 @testset "config creation" begin
-    conf = load_config()
-    @test conf isa RAI.Config 
+    if (isfile(joinpath(homedir(),".rai","config")))
+        conf = load_config()
+        @test conf isa RAI.Config 
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,10 @@ import Tables
 using RAI
 using Test
 
+@testset "config.jl" begin
+    include("config.jl")
+end
+
 @testset "rest.jl" begin
     include("rest.jl")
 end


### PR DESCRIPTION
Hello friends, this is my first PR to rai-sdk-julia so please let me know what I did wrong!

I'm a Windows user in this particular instance and I noticed configs can't be created because of a non-portable use of "~/.rai/config" which ConfParser does not expand properly.  I updated it to use homedir/joinpath.

One questionable part is the test which is perhaps a bit tautological but I just wanted a test for 'not exploding'