### PR TITLE
Readme tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # The RelationalAI Software Development Kit for Julia
 
-The RelationalAI (RAI) SDK for Julia enables developers to access the RAI REST APIs from Julia. 
+The RelationalAI (RAI) SDK for Julia enables developers to access the RAI REST APIs from Julia.
 
-* You can find RelationalAI Julia SDK documentation at <https://docs.relational.ai/rkgms/sdk/julia-sdk> 
-* You can find RelationalAI product documentation at <https://docs.relational.ai> 
-* You can learn more about RelationalAI at <https://relational.ai> ## Getting started
+* You can find RelationalAI Julia SDK documentation at <https://docs.relational.ai/rkgms/sdk/julia-sdk>
+* You can find RelationalAI product documentation at <https://docs.relational.ai>
+* You can learn more about RelationalAI at <https://relational.ai>
+
+## Getting started
 
 ### Installation
 


### PR DESCRIPTION
The "getting started" header was trailing after the previous line, which seemed like a mistake; hopefully this is the right fix.