### PR TITLE
Bump up default connection_limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.2.1
+* Increased `connection_limit` to 4096
+
 ## v0.2.0
 * Deprecate metadata JSON format.
 * Add support to deserialize ProtoBuf metadata.

--- a/src/rest.jl
+++ b/src/rest.jl
@@ -120,6 +120,6 @@ function request(
     isnothing(body) && (body = UInt8[])
     headers = _ensure_headers!(headers)
     _authenticate!(ctx, headers)
-    opts = (;redirect = false)
+    opts = (;redirect = false, connection_limit = 4096)
     return HTTP.request(method, url, headers; query = query, body = body, opts..., kw...)
 end


### PR DESCRIPTION
As we did in https://github.com/RelationalAI/raicode/commit/29ce2059fdf61eebb44e6fa888c8e247f5689233