### PR TITLE
Added custom engine version support in the integration tests

### DIFF
--- a/test/integration.jl
+++ b/test/integration.jl
@@ -50,8 +50,14 @@ rnd_test_name() = "julia-sdk-" * string(UUIDs.uuid4())
 function with_engine(f, ctx; existing_engine=nothing)
     engine_name = rnd_test_name()
     if isnothing(existing_engine)
+        engine_version = get(ENV, "RAI_ENGINE_VERSION", nothing)
         start_time_ns = time_ns()
-        create_engine(ctx, engine_name)
+        if isnothing(engine_version)
+            create_engine(ctx, engine_name)
+        else
+            custom_headers = Dict(:"x-rai-parameter-compute-version"=>engine_version)
+            create_engine(ctx, engine_name; "XS", custom_headers)
+        end
         _poll_with_specified_overhead(; POLLING_KWARGS..., start_time_ns) do
             get_engine(ctx, engine_name)[:state] == "PROVISIONED"
         end

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -56,7 +56,7 @@ function with_engine(f, ctx; existing_engine=nothing)
             create_engine(ctx, engine_name)
         else
             custom_headers = Dict(:"x-rai-parameter-compute-version"=>engine_version)
-            create_engine(ctx, engine_name; "XS", custom_headers)
+            create_engine(ctx, engine_name; nothing, custom_headers)
         end
         _poll_with_specified_overhead(; POLLING_KWARGS..., start_time_ns) do
             get_engine(ctx, engine_name)[:state] == "PROVISIONED"

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -1,6 +1,5 @@
 using Test
 using RAI
-using JSON
 using ArgParse
 using RAI: transaction_id, _poll_with_specified_overhead
 
@@ -18,8 +17,8 @@ function parse_test_args()
     s = ArgParseSettings()
 
     @add_arg_table s begin
-        "--extra_headers"
-            help = "an option to pass extra headers"
+        "--custom_headers"
+            help = "an option to pass custom headers"
             required = false
     end
 
@@ -65,15 +64,14 @@ rnd_test_name() = "julia-sdk-" * string(UUIDs.uuid4())
 function with_engine(f, ctx; existing_engine=nothing)
     engine_name = rnd_test_name()
     if isnothing(existing_engine)
-        extra_headers = parse_test_args()
+        custom_headers = parse_test_args()
         start_time_ns = time_ns()
-        if isnothing(extra_headers["extra_headers"])
+        if isnothing(custom_headers["custom_headers"])
             create_engine(ctx, engine_name)
         else
-            # extra headers should be passed as a JSON string
+            # custom headers should be passed as a JSON string
             # otherwise a runtime exception will be thrown
-            print("Extra Headers \n")
-            headers = Dict{String,String}(JSON.parse(extra_headers["extra_headers"]))
+            headers = JSON3.read(custom_headers["custom_headers"], Dict{String, String})
             create_engine(ctx, engine_name; nothing, headers)
         end
         _poll_with_specified_overhead(; POLLING_KWARGS..., start_time_ns) do


### PR DESCRIPTION
Integration tests can honor an environment variable like  CUSTOM_HEADERS= '{"key1":"val1", "key2":"val2"}'. The custom headers key value pair should be valid JSON string otherwise, I runtime error will be thrown. The JSON string will be parsed into a dictionary and will passed to the create_engine function as kwargs...


export CUSTOM_HEADERS='{"x-rai-parameter-compute-version":"6df2736eccdc6a4844c2f8e8d78bcd7782046e1d"}'