### PR TITLE
RAI-8289 add suspend/resume functionality to julia sdk

### DIFF
--- a/src/RAI.jl
+++ b/src/RAI.jl
@@ -43,7 +43,9 @@ export
     create_engine,
     delete_engine,
     get_engine,
-    list_engines
+    list_engines,
+    suspend_engine,
+    resume_engine
 
 export
     delete_models,

--- a/src/api.jl
+++ b/src/api.jl
@@ -207,7 +207,7 @@ function _request(ctx::Context, method, path; query = nothing, body = UInt8[], k
     # _print_request(method, path, query, body);
     try
         rsp = @mock request(ctx, method, _mkurl(ctx, path); query = query, body = body, kw...)
-        if rsp.status == 202
+        if length(rsp.body) == 0
             return Dict()
         else
             return JSON3.read(rsp.body)

--- a/src/api.jl
+++ b/src/api.jl
@@ -244,12 +244,12 @@ end
 
 function suspend_engine(ctx::Context, engine::AbstractString; kw...)
     payload=Dict("suspend" => true)
-    return _patch(ctx, joinpath(PATH_ENGINE, engine); body=JSON3.write(payload), kw...)
+    return _patch(ctx, "$PATH_ENGINE/$engine"; body=JSON3.write(payload), kw...)
 end
 
 function resume_engine(ctx::Context, engine::AbstractString; kw...)
     payload=Dict("suspend" => false)
-    return _patch(ctx, joinpath(PATH_ENGINE, engine); body=JSON3.write(payload), kw...)
+    return _patch(ctx, "$PATH_ENGINE/$engine"; body=JSON3.write(payload), kw...)
 end
 
 function create_oauth_client(ctx::Context, name::AbstractString, permissions; kv...)

--- a/src/api.jl
+++ b/src/api.jl
@@ -181,7 +181,11 @@ function _request(ctx::Context, method, path; query = nothing, body = UInt8[], k
     # _print_request(method, path, query, body);
     try
         rsp = @mock request(ctx, method, _mkurl(ctx, path); query = query, body = body, kw...)
-        return JSON3.read(rsp.body)
+        if rsp.status == 202
+            return Dict()
+        else
+            return JSON3.read(rsp.body)
+        end
     catch e
         if e isa HTTP.ExceptionRequest.StatusError
             throw(HTTPError(e.status, String(e.response.body)))
@@ -210,6 +214,16 @@ function create_engine(ctx::Context, engine::AbstractString; size = nothing, kw.
     isnothing(size) && (size = "XS")
     data = Dict("region" => ctx.region, "name" => engine, "size" => size)
     return _put(ctx, PATH_ENGINE; body = JSON3.write(data), kw...)
+end
+
+function suspend_engine(ctx::Context, engine::AbstractString; kw...)
+    payload=Dict("suspend" => true)
+    return _patch(ctx, joinpath(PATH_ENGINE, engine); body=JSON3.write(payload), kw...)
+end
+
+function resume_engine(ctx::Context, engine::AbstractString; kw...)
+    payload=Dict("suspend" => false)
+    return _patch(ctx, joinpath(PATH_ENGINE, engine); body=JSON3.write(payload), kw...)
 end
 
 function create_oauth_client(ctx::Context, name::AbstractString, permissions; kv...)

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -140,6 +140,25 @@ const CTX = test_context()
 end
 
 # -----------------------------------
+# suspend and resume
+with_engine(CTX) do engine_name
+    @testset "suspend" begin
+        suspend_engine(CTX, engine_name)
+        stns = time_ns()
+        _poll_with_specified_overhead(; POLLING_KWARGS..., st_ns) do
+            eng = get_engine(CTX, engine_name)
+            return eng[:state] == "SUSPENDED" && eng[:suspend] == true
+        end
+        resume_engine(CTX, engine_name)
+        _poll_with_specified_overhead(; POLLING_KWARGS..., st_ns) do
+            eng = get_engine(CTX, engine_name)
+            return eng[:state] == "PROVISIONED" && eng[:suspend] == false
+        end
+    end
+end
+
+
+# -----------------------------------
 # transactions
 
 with_engine(CTX) do engine_name

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -119,13 +119,14 @@ const CTX = test_context()
 with_engine(CTX) do engine_name
     @testset "suspend" begin
         suspend_engine(CTX, engine_name)
-        stns = time_ns()
-        _poll_with_specified_overhead(; POLLING_KWARGS..., st_ns) do
+        start_time = time()
+        _poll_with_specified_overhead(; POLLING_KWARGS..., start_tiome) do
             eng = get_engine(CTX, engine_name)
             return eng[:state] == "SUSPENDED" && eng[:suspend] == true
         end
         resume_engine(CTX, engine_name)
-        _poll_with_specified_overhead(; POLLING_KWARGS..., st_ns) do
+        start_time = time()
+        _poll_with_specified_overhead(; POLLING_KWARGS..., start_time) do
             eng = get_engine(CTX, engine_name)
             return eng[:state] == "PROVISIONED" && eng[:suspend] == false
         end

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -120,7 +120,7 @@ with_engine(CTX) do engine_name
     @testset "suspend" begin
         suspend_engine(CTX, engine_name)
         start_time = time()
-        _poll_with_specified_overhead(; POLLING_KWARGS..., start_tiome) do
+        _poll_with_specified_overhead(; POLLING_KWARGS..., start_time) do
             eng = get_engine(CTX, engine_name)
             return eng[:state] == "SUSPENDED" && eng[:suspend] == true
         end


### PR DESCRIPTION
This introduces `suspend_engine` and `resume_engine` methods that can suspend and resume engines. Relies on https://github.com/RelationalAI/raicloud-control-plane/pull/4108 to be merged and deployed. 