### PR TITLE
Enhance http errors reporting

### DIFF
--- a/test/integration.jl
+++ b/test/integration.jl
@@ -55,8 +55,10 @@ rnd_test_name() = "julia-sdk-" * string(UUIDs.uuid4())
 # finished. An already existing engine can be supplied to improve local iteration times.
 function with_engine(f, ctx; existing_engine=nothing)
     engine_name = rnd_test_name()
+    @info "using engine $engine_name"
     if isnothing(existing_engine)
         custom_headers = get(ENV, "CUSTOM_HEADERS", nothing)
+        custom_headers !== nothing && @info "using custom headers $custom_headers"
         start_time_ns = time_ns()
         if isnothing(custom_headers)
             create_engine(ctx, engine_name)
@@ -96,6 +98,7 @@ end
 # iteration times.
 function with_database(f, ctx; existing_database=nothing)
     dbname = rnd_test_name()
+    @info "using database $dbname"
     isnothing(existing_database) &&
         create_database(ctx, dbname)
     try

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -55,10 +55,10 @@ rnd_test_name() = "julia-sdk-" * string(UUIDs.uuid4())
 # finished. An already existing engine can be supplied to improve local iteration times.
 function with_engine(f, ctx; existing_engine=nothing)
     engine_name = rnd_test_name()
-    @info "using engine $engine_name"
     if isnothing(existing_engine)
+        @info "using engine $engine_name"
         custom_headers = get(ENV, "CUSTOM_HEADERS", nothing)
-        custom_headers !== nothing && @info "using custom headers $custom_headers"
+        !isnothing(custom_headers) && @info "using custom headers $custom_headers"
         start_time_ns = time_ns()
         if isnothing(custom_headers)
             create_engine(ctx, engine_name)
@@ -74,6 +74,7 @@ function with_engine(f, ctx; existing_engine=nothing)
             state == "PROVISIONED"
         end
     else
+        @info "using engine $existing_engine"
         engine_name = existing_engine
     end
     try
@@ -98,9 +99,11 @@ end
 # iteration times.
 function with_database(f, ctx; existing_database=nothing)
     dbname = rnd_test_name()
-    @info "using database $dbname"
-    isnothing(existing_database) &&
+    if isnothing(existing_database)
+        @info "using database $dbname"
         create_database(ctx, dbname)
+    end
+
     try
         f(dbname)
     finally


### PR DESCRIPTION
Throw a `HTTPError` containing the `request id` + `response body` if bad http response. This will help correlate errors with related database and engine in datadog.
Added used engine and database logs to integration tests