### PR TITLE
RAI-8577: add debug logging in polling loop

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -137,7 +137,10 @@ function _poll_with_specified_overhead(
     local iter
     for i in 1:n
         iter = i
-        if f()
+        @debug "polling: sending request"
+        done = f()
+        @debug "polling: request complete" done
+        if done
             return nothing
         end
         current_delay = time_ns() - start_time_ns


### PR DESCRIPTION
Trying to track down mysterious hangs in https://relationalai.atlassian.net/browse/RAI-8577