### PR TITLE
Fix the arithmetic for wait_until_done(); add `start_time` kwarg in seconds, instead of ns.

### DIFF
--- a/test/api.jl
+++ b/test/api.jl
@@ -13,6 +13,8 @@ import ProtoBuf
 
 Mocking.activate()
 
+include("wait_until_done.jl")
+
 # -----------------------------------
 # v2 transactions
 
@@ -269,7 +271,7 @@ end
         )
 
         apply(metadata_404_patch) do
-            RAI.wait_until_done(ctx, "<txn-id>", start_time_ns=0)
+            RAI.wait_until_done(ctx, "<txn-id>", start_time=0)
         end
     end
 

--- a/test/integration.jl
+++ b/test/integration.jl
@@ -57,7 +57,7 @@ function with_engine(f, ctx; existing_engine=nothing)
     engine_name = rnd_test_name()
     if isnothing(existing_engine)
         custom_headers = get(ENV, "CUSTOM_HEADERS", nothing)
-        start_time_ns = time_ns()
+        start_time = time()
         if isnothing(custom_headers)
             create_engine(ctx, engine_name)
         else
@@ -66,7 +66,7 @@ function with_engine(f, ctx; existing_engine=nothing)
             headers = JSON3.read(custom_headers, Dict{String, String})
             create_engine(ctx, engine_name; nothing, headers)
         end
-        _poll_with_specified_overhead(; POLLING_KWARGS..., start_time_ns) do
+        _poll_with_specified_overhead(; POLLING_KWARGS..., start_time) do
             state = get_engine(ctx, engine_name)[:state]
             state == "PROVISION_FAILED" && throw("Failed to provision engine $engine_name")
             state == "PROVISIONED"
@@ -80,8 +80,8 @@ function with_engine(f, ctx; existing_engine=nothing)
         # Engines cannot be deleted if they are still provisioning. We have to at least wait
         # until they are ready.
         if isnothing(existing_engine)
-            start_time_ns = time_ns() - 2e9  # assume we started 2 seconds ago
-            _poll_with_specified_overhead(; POLLING_KWARGS..., start_time_ns) do
+            start_time = time() - 2  # assume we started 2 seconds ago
+            _poll_with_specified_overhead(; POLLING_KWARGS..., start_time) do
                 state = get_engine(ctx, engine_name)[:state]
                 state == "PROVISION_FAILED" && throw("Failed to provision engine $engine_name")
                 state == "PROVISIONED"

--- a/test/wait_until_done.jl
+++ b/test/wait_until_done.jl
@@ -1,0 +1,72 @@
+using ExceptionUnwrapping: unwrap_exception_to_root
+
+# This test is _pretty complicated_ since it's trying to test something that depends on
+# timing: testing that wait_until_done() polls for the expected amount of time in between
+# calls to get_transaction.
+# Testing anything to do with timing is always complicated. We tackle it here by mocking
+# both sleep() and time(), and injecting fake times, and then making sure that the
+# function is computing the correct duration to sleep, based on those times.
+@testset "wait_until_done polls correctly" begin
+    now_ms = round(Int, time() * 1e3)
+    txn_str = """{
+            "id": "a3e3bc91-0a98-50ba-733c-0987e160eb7d",
+            "results_format_version": "2.0.1",
+            "state": "RUNNING",
+            "created_on": $(now_ms)
+        }"""
+    txn = JSON3.read(txn_str)
+
+    ctx = Context("region", "scheme", "host", "2342", nothing, "audience")
+
+    start = now_ms / 1e3
+    # Simulate OVERHEAD of 0.1 + round-trip-time of 0.5
+    times = [
+        start + 2,            # First call takes 2 seconds then returns async
+        start + 2.2 + 0.5,    # So we slept 0.2 seconds, then get_txn takes 0.5 secs
+        start + 2.97 + 0.5    # Now we sleep 2.7 * 1.1 ≈ 2.97, then again 0.5 RTT.
+    ]
+    i = 1
+    time_patch = @patch function Base.time()
+        v = times[i]
+        i += 1
+        return v
+    end
+    # Here, we test that each call to sleep is the correct calculation of current "time"
+    # minus start time * the overhead.
+    sleep_patch = @patch function Base.sleep(duration)
+        @info "Mock sleep for $duration"
+        @test duration ≈ (times[i-1] - start) * RAI.TXN_POLLING_OVERHEAD
+    end
+
+    # This is returned on each get_txn() request.
+    unfinished_response = HTTP.Response(
+        200,
+        ["Content-Type" => "application/json"],
+        body = """{"transaction": $(txn_str)}"""
+    )
+
+    # Stop the test after 3 polls.
+    ABORT = :ABORT_TEST
+
+    request_patch = @patch function RAI.request(ctx::Context, args...; kw...)
+        if i <= 3
+            return unfinished_response
+        else
+            # Finish the test
+            throw(ABORT)
+        end
+    end
+
+    # Call the function with the patches. Assert that it ends with our ABORT exception.
+    apply([time_patch, sleep_patch, request_patch]) do
+        try
+            wait_until_done(ctx, txn)
+        catch e
+            @assert unwrap_exception_to_root(e) == ABORT
+        end
+    end
+
+    # Test that we made it through all the expected polls, so that we know the above
+    # `@test`s all triggered.
+    @test i == 4
+end


### PR DESCRIPTION
Correctly account for the time sent from the API (ms since epoch), and
add a new parameter, start_time, which is in *seconds* not nanoseconds.

Deprecate the old parameter, to be removed in a future release.

Also adds an complex mocked test for wait_until_done, which tests that it really is waiting for the expected time, based on the created_on field from the API, which comes back in milliseconds.

--------------

The actual src/ changes are pretty straightforward:
- change from ns to seconds: the API returns the unix timestamp in ms and julia's `time()` function returns timestamp in seconds (to ~microsecond precision).

But then i made the PR more complicated by:
- keeping the old interface to make the change backwards compatible, and
- adding a complicated mocked unit test to make sure we're testing the behavior here and it's working as we expected

... sorry for the extra complexity.