### PR TITLE
fix: export `cancel_transaction`

### DIFF
--- a/src/RAI.jl
+++ b/src/RAI.jl
@@ -79,6 +79,7 @@ export
     load_json
 
 export
+    cancel_transaction,
     get_transaction,
     get_transaction_metadata,
     get_transaction_problems,


### PR DESCRIPTION
Going through the sdk docs, it seems like `cancel_transaction` ought to be exported. This PR does that.

https://docs.relational.ai/rkgms/sdk/julia-sdk#transaction-cancellation