### PR TITLE
add pretty printer for MetadataInfo

### DIFF
--- a/src/gen/relationalai/protocol/message_pb.jl
+++ b/src/gen/relationalai/protocol/message_pb.jl
@@ -74,6 +74,6 @@ function PB._encoded_size(x::MetadataInfo)
 end
 
 # Pretty printer to prevent large amounts of Metadata from being printed.
-function Base.show(io::IO, x::MetadataInfo)
+function Base.show(io::IO, ::MIME"text/plain", x::MetadataInfo)
     print(io, "MetadataInfo (length=", length(x.relations), ")")
 end

--- a/src/gen/relationalai/protocol/message_pb.jl
+++ b/src/gen/relationalai/protocol/message_pb.jl
@@ -72,3 +72,8 @@ function PB._encoded_size(x::MetadataInfo)
     !isempty(x.relations) && (encoded_size += PB._encoded_size(x.relations, 1))
     return encoded_size
 end
+
+# Pretty printer to prevent large amounts of Metadata from being printed.
+function Base.show(io::IO, x::MetadataInfo)
+    print(io, "MetadataInfo (length=", length(x.relations), ")")
+end


### PR DESCRIPTION
In interactive use, this struct can print a lot of information that the user cannot directly interpret. This PR defines a pretty printer to avoid the wall of text.