### PR TITLE
fix: update connection_limit per warning

### DIFF
--- a/src/rest.jl
+++ b/src/rest.jl
@@ -184,6 +184,6 @@ function request(
     isnothing(body) && (body = UInt8[])
     headers = _ensure_headers(headers)
     _authenticate!(ctx, headers)
-    opts = (;redirect = false, connection_limit = 4096)
+    opts = (;redirect = false, pool = HTTP.Pool(4096))
     return HTTP.request(method, url, headers; query = query, body = body, opts..., kw...)
 end


### PR DESCRIPTION
In doing some testing on `RAITest`, I updated the deps and got a ton of warnings about connection_limit (see [logs](https://github.com/RelationalAI/raicode/actions/runs/4887254317/jobs/8723755736)). This implements one of the suggestions.