### PR TITLE
Backport for 0.1 release: Don't use Pkg to compute project-version.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RAI"
 uuid = "9c30249a-7e08-11ec-0e99-a323e937e79f"
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]

--- a/src/RAI.jl
+++ b/src/RAI.jl
@@ -20,10 +20,11 @@ APIs.
 """
 module RAI
 
-import Pkg
+import TOML
 
 # Used for sending the User Agent.
-const PROJECT_VERSION = Pkg.project().version
+project_toml = joinpath(dirname(@__DIR__), "Project.toml")
+const PROJECT_VERSION = TOML.parsefile(project_toml)["version"]
 
 export
     AccessToken,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,12 @@ end
     include("integration.jl")
 end
 
+@testset "user-agent" begin
+    @test RAI.PROJECT_VERSION isa String
+    @test !isempty(RAI.PROJECT_VERSION)
+    @test occursin(r"^rai-sdk-julia/\d+\.\d+\.\d+$", RAI._user_agent())
+end
+
 # def output =
 #     1, "foo", 3.4, :foo;
 #     2, "bar", 5.6, :foo


### PR DESCRIPTION
This feature from Pkg is apparently "experimental" and not well supported, so it's safer to just read from the TOML file ourselves.

Also, TOML is a much smaller dependency than Pkg.
Backports https://github.com/RelationalAI/rai-sdk-julia/pull/114.